### PR TITLE
Bug/joint wasserstein gan

### DIFF
--- a/src/configs/JointGAN/cifar/joint-wgan-gp.yaml
+++ b/src/configs/JointGAN/cifar/joint-wgan-gp.yaml
@@ -2,6 +2,10 @@ DATA:
   name: "CIFAR10"
   img_size: 32
   num_classes: 10
+MODEL:
+  backbone: "jointgan.deep_conv"
+  g_conv_dim: "N/A"
+  d_conv_dim: "N/A"
 LOSS:
   adv_loss: "wasserstein_relativistic"
   apply_gp: True

--- a/src/configs/JointGAN/imagenet-tiny/joint-wgan-gp.yaml
+++ b/src/configs/JointGAN/imagenet-tiny/joint-wgan-gp.yaml
@@ -1,9 +1,9 @@
-MODEL:
-  backbone: "jointgan.resnet"
 DATA:
   name: "Tiny_ImageNet"
   img_size: 64
   num_classes: 200
+MODEL:
+  backbone: "jointgan.resnet"
 LOSS:
   adv_loss: "wasserstein_relativistic"
   apply_gp: True

--- a/src/utils/losses.py
+++ b/src/utils/losses.py
@@ -367,6 +367,31 @@ def cal_grad_penalty(real_images, real_labels, fake_images, discriminator, devic
     return grad_penalty
 
 
+def cal_grad_penalty_with_reference(real_images, real_labels, fake_images, discriminator, device):
+    batch_size, c, h, w = real_images.shape
+    alpha = torch.rand(batch_size, 1)
+    alpha = alpha.expand(batch_size, real_images.nelement() // batch_size).contiguous().view(batch_size, c, h, w)
+    alpha = alpha.to(device)
+
+    real_images = real_images.to(device)
+    interpolates = alpha * real_images + (1 - alpha) * fake_images
+    interpolates = interpolates.to(device)
+    interpolates = autograd.Variable(interpolates, requires_grad=True)
+
+    references = (1 - alpha) * real_images + (alpha * fake_images)
+    references = references.to(device)
+    references = autograd.Variable(references, requires_grad=True)
+
+    fake_dict = discriminator((interpolates, references), real_labels, eval=False)
+    
+    grads1 = cal_deriv(inputs=interpolates, outputs=fake_dict["adv_output"], device=device).view(grads1.size(0), -1)
+    grads2 = cal_deriv(inputs=references, outputs=fake_dict["adv_output"], device=device).view(grads2.size(0), -1)
+    grads = torch.cat([grads1, grads2], dim=1)
+
+    grad_penalty = ((grads.norm(2, dim=1) - 1)**2).mean() + interpolates[:,0,0,0].mean()*0
+    return grad_penalty
+
+
 def cal_dra_penalty(real_images, real_labels, discriminator, device):
     batch_size, c, h, w = real_images.shape
     alpha = torch.rand(batch_size, 1, 1, 1)

--- a/src/utils/losses.py
+++ b/src/utils/losses.py
@@ -378,7 +378,7 @@ def cal_grad_penalty_with_reference(real_images, real_labels, fake_images, discr
     interpolates = interpolates.to(device)
     interpolates = autograd.Variable(interpolates, requires_grad=True)
 
-    references = (1 - alpha) * real_images + (alpha * fake_images)
+    references = (1 - alpha) * real_images + alpha * fake_images
     references = references.to(device)
     references = autograd.Variable(references, requires_grad=True)
 

--- a/src/utils/losses.py
+++ b/src/utils/losses.py
@@ -384,8 +384,8 @@ def cal_grad_penalty_with_reference(real_images, real_labels, fake_images, discr
 
     fake_dict = discriminator((interpolates, references), real_labels, eval=False)
     
-    grads1 = cal_deriv(inputs=interpolates, outputs=fake_dict["adv_output"], device=device).view(grads1.size(0), -1)
-    grads2 = cal_deriv(inputs=references, outputs=fake_dict["adv_output"], device=device).view(grads2.size(0), -1)
+    grads1 = cal_deriv(inputs=interpolates, outputs=fake_dict["adv_output"], device=device).view(batch_size, -1)
+    grads2 = cal_deriv(inputs=references, outputs=fake_dict["adv_output"], device=device).view(batch_size, -1)
     grads = torch.cat([grads1, grads2], dim=1)
 
     grad_penalty = ((grads.norm(2, dim=1) - 1)**2).mean() + interpolates[:,0,0,0].mean()*0

--- a/src/worker.py
+++ b/src/worker.py
@@ -375,11 +375,18 @@ class WORKER(object):
 
                     # apply gradient penalty regularization to train wasserstein GAN
                     if self.LOSS.apply_gp:
-                        gp_loss = losses.cal_grad_penalty(real_images=real_images,
-                                                          real_labels=real_labels,
-                                                          fake_images=fake_images,
-                                                          discriminator=self.Dis,
-                                                          device=self.local_rank)
+                        if "jointgan." in self.MODEL.backbone:
+                            gp_loss = losses.cal_grad_penalty_with_reference(real_images=real_images,
+                                                                             real_labels=real_labels,
+                                                                             fake_images=fake_images,
+                                                                             discriminator=self.Dis,
+                                                                             device=self.local_rank)
+                        else:
+                            gp_loss = losses.cal_grad_penalty(real_images=real_images,
+                                                            real_labels=real_labels,
+                                                            fake_images=fake_images,
+                                                            discriminator=self.Dis,
+                                                            device=self.local_rank)
                         dis_acml_loss += self.LOSS.gp_lambda * gp_loss
 
                     # apply deep regret analysis regularization to train wasserstein GAN


### PR DESCRIPTION
### **It had some critical bugs**

1. CIFAR 10 's Joint-WGAN model **used ordinary discriminator** model (not JointGAN discriminator)
2. Gradient penalty was **not applied for (real, fake) / (fake, real) tuple**. Instead it just used one (real) or (fake) image.

All the bugs stated above are fixed here.